### PR TITLE
project: rename the organization to Nope Forge

### DIFF
--- a/.github/workflows/ci_android.yml
+++ b/.github/workflows/ci_android.yml
@@ -59,7 +59,7 @@ jobs:
 
     - name: Build nope.media for Android & reshape files tree
       run: |
-        curl -sL https://github.com/NopeFoundry/nope.media/archive/refs/tags/v${{ matrix.nopemd_version }}.tar.gz -o nope.media.tgz
+        curl -sL https://github.com/NopeForge/nope.media/archive/refs/tags/v${{ matrix.nopemd_version }}.tar.gz -o nope.media.tgz
         tar xf nope.media.tgz
         cd nope.media-${{ matrix.nopemd_version }}
         PKG_CONFIG_LIBDIR=$HOME/ngl-env-${{ matrix.arch }}/lib/pkgconfig/ \

--- a/.github/workflows/ci_ios.yml
+++ b/.github/workflows/ci_ios.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Build nope.media for ios & reshape files tree
       run: |
-        curl -sL https://github.com/NopeFoundry/nope.media/archive/refs/tags/v${{ matrix.nopemd_version }}.tar.gz -o nope.media.tgz
+        curl -sL https://github.com/NopeForge/nope.media/archive/refs/tags/v${{ matrix.nopemd_version }}.tar.gz -o nope.media.tgz
         tar xf nope.media.tgz
         cd nope.media-${{ matrix.nopemd_version }}
         PKG_CONFIG_LIBDIR=$HOME/ngl-env-${{ matrix.arch }}/lib/pkgconfig \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,7 +109,7 @@ Versioning](https://semver.org/spec/v2.0.0.html) for `libnopegl`.
 
 ## [2023.1] [libnopegl 0.8.0] - 2023-04-07
 ### Changed
-- Project renamed to `nope.gl`, as part of the Nope Foundry
+- Project renamed to `nope.gl`
 
 ----
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,8 +1,8 @@
-Nope Foundry nope.gl
+Nope Forge nope.gl
 Copyright 2023
 
 This product includes software developed at
-the Nope Foundry.
+the Nope Forge.
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -7,15 +7,15 @@ iOS).
 **Warning:** note that `nope.gl` is still highly experimental. This means the ABI
 and API can change at any time.
 
-📚 [Documentation](https://nopefoundry.github.io/nope.gl)
+📚 [Documentation](https://nopeforge.github.io/nope.gl)
 
-![tests Linux](https://github.com/NopeFoundry/nope.gl/workflows/tests%20Linux/badge.svg)
-![tests Mac](https://github.com/NopeFoundry/nope.gl/workflows/tests%20Mac/badge.svg)
-![tests MinGW](https://github.com/NopeFoundry/nope.gl/workflows/tests%20MinGW/badge.svg)
-![tests MSVC](https://github.com/NopeFoundry/nope.gl/workflows/tests%20MSVC/badge.svg)
-[![coverage](https://codecov.io/gh/NopeFoundry/nope.gl/branch/main/graph/badge.svg)](https://codecov.io/gh/NopeFoundry/nope.gl)
-![build Android 🤖](https://github.com/NopeFoundry/nope.gl/workflows/build%20Android%20🤖/badge.svg)
-![build iOS 🍏](https://github.com/NopeFoundry/nope.gl/workflows/build%20iOS%20🍏/badge.svg)
+![tests Linux](https://github.com/NopeForge/nope.gl/workflows/tests%20Linux/badge.svg)
+![tests Mac](https://github.com/NopeForge/nope.gl/workflows/tests%20Mac/badge.svg)
+![tests MinGW](https://github.com/NopeForge/nope.gl/workflows/tests%20MinGW/badge.svg)
+![tests MSVC](https://github.com/NopeForge/nope.gl/workflows/tests%20MSVC/badge.svg)
+[![coverage](https://codecov.io/gh/NopeForge/nope.gl/branch/main/graph/badge.svg)](https://codecov.io/gh/NopeForge/nope.gl)
+![build Android 🤖](https://github.com/NopeForge/nope.gl/workflows/build%20Android%20🤖/badge.svg)
+![build iOS 🍏](https://github.com/NopeForge/nope.gl/workflows/build%20iOS%20🍏/badge.svg)
 
 
 ## 📜 License

--- a/configure.py
+++ b/configure.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright 2023 Nope Foundry
+# Copyright 2023 Nope Forge
 # Copyright 2021-2022 GoPro Inc.
 #
 # Licensed to the Apache Software Foundation (ASF) under one
@@ -53,7 +53,7 @@ _EXTERNAL_DEPS = dict(
     ),
     nopemd=dict(
         version="11.1.0",
-        url="https://github.com/NopeFoundry/nope.media/archive/v@VERSION@.tar.gz",
+        url="https://github.com/NopeForge/nope.media/archive/v@VERSION@.tar.gz",
         dst_file="nope.media-@VERSION@.tar.gz",
         sha256="262d0841471276acb7f224610286b1cde360df3440dc9a07e01fd5488e44adfb",
     ),

--- a/doc/_ext/nope/__init__.py
+++ b/doc/_ext/nope/__init__.py
@@ -1,6 +1,6 @@
 #
 # Copyright 2023 Clément Bœsch <u pkh.me>
-# Copyright 2023 Nope Foundry
+# Copyright 2023 Nope Forge
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -5,7 +5,7 @@ from pathlib import Path
 sys.path.append((Path(__file__).resolve().parent / "_ext").as_posix())
 
 # Project information
-project = "Nope Foundry"
+project = "Nope Forge"
 project_copyright = f"2023 {project}"
 author = "Clément Bœsch"
 version = "main"
@@ -26,5 +26,5 @@ myst_heading_anchors = 3
 myst_url_schemes = dict(
     http=None,
     https=None,
-    source=f"https://github.com/NopeFoundry/nope.gl/tree/{version}/" + "{{path}}",
+    source=f"https://github.com/NopeForge/nope.gl/tree/{version}/" + "{{path}}",
 )

--- a/doc/dev/ref/architecture.md
+++ b/doc/dev/ref/architecture.md
@@ -61,7 +61,7 @@ graph
 ```
 
 [meson]: https://mesonbuild.com/
-[nope_media]: https://github.com/NopeFoundry/nope.media
+[nope_media]: https://github.com/NopeForge/nope.media
 [graphviz]: http://www.graphviz.org/
 [python]: https://www.python.org/
 [cython]: http://cython.org/

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,6 +1,6 @@
-# Nope Foundry documentation
+# Nope Forge documentation
 
-The [Nope Foundry project][nope-foundry] provides a free and open source cross-platform
+The [Nope Forge project][nopeforge] provides a free and open source cross-platform
 framework for **motion design**, **2D composition** and **visual effects**.
 
 This documentation is split into 2 main sections: **user** and **developers**
@@ -25,5 +25,5 @@ usr/index.md
 dev/index.md
 ```
 
-[nope-foundry]: https://www.nope-foundry.org
-[nopegl]: https://github.com/NopeFoundry/nope.gl
+[nopeforge]: https://www.nopeforge.org
+[nopegl]: https://github.com/NopeForge/nope.gl

--- a/doc/usr/expl/scopes.md
+++ b/doc/usr/expl/scopes.md
@@ -97,4 +97,4 @@ Additional details:
 [Block]: /usr/ref/libnopegl.md#block
 [Render]: /usr/ref/libnopegl.md#render
 [Compute]: /usr/ref/libnopegl.md#compute
-[nope.demos]: https://github.com/NopeFoundry/nope.demos
+[nope.demos]: https://github.com/NopeForge/nope.demos

--- a/doc/usr/howto/installation.md
+++ b/doc/usr/howto/installation.md
@@ -2,14 +2,14 @@
 
 ## Download
 
-The sources can be downloaded on the [NopeFoundry/nope.gl GitHub repository][nopegl],
+The sources can be downloaded on the [NopeForge/nope.gl GitHub repository][nopegl],
 either by downloading a zip snapshot or cloning them with `git`:
 
 ```sh
-git clone https://github.com/NopeFoundry/nope.gl
+git clone https://github.com/NopeForge/nope.gl
 ```
 
-[nopegl]: https://github.com/NopeFoundry/nope.gl
+[nopegl]: https://github.com/NopeForge/nope.gl
 
 
 ## Method 1: quick user build & installation

--- a/doc/usr/tuto/start.md
+++ b/doc/usr/tuto/start.md
@@ -12,7 +12,7 @@ installation guide][install]. In a nutshell: `./configure.py && make` creates a
 complete Python-based working environment. Within that virtual environment, the
 `ngl-viewer` command is available.
 
-[releases]: https://github.com/NopeFoundry/nope.gl/releases/
+[releases]: https://github.com/NopeForge/nope.gl/releases/
 [install]: /usr/howto/installation.md
 
 ## Creating a simple scene in Python

--- a/libnopegl/meson.build
+++ b/libnopegl/meson.build
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Nope Foundry
+# Copyright 2023 Nope Forge
 # Copyright 2020-2022 GoPro Inc.
 #
 # Licensed to the Apache Software Foundation (ASF) under one
@@ -735,7 +735,7 @@ endif
 
 # Create nopegl version data for rc
 nopegl_version_cdata = configuration_data()
-nopegl_version_cdata.set('NOPEGL_COPYRIGHT', 'Copyright Nope Foundry')
+nopegl_version_cdata.set('NOPEGL_COPYRIGHT', 'Copyright Nope Forge')
 nopegl_version_cdata.set('NOPEGL_MAJOR_VERSION', version_array[0])
 nopegl_version_cdata.set('NOPEGL_MINOR_VERSION', version_array[1])
 nopegl_version_cdata.set('NOPEGL_MICRO_VERSION', version_array[2])

--- a/libnopegl/nopegl.rc.in
+++ b/libnopegl/nopegl.rc.in
@@ -13,7 +13,7 @@ VS_VERSION_INFO VERSIONINFO
     BEGIN
       BLOCK "040904B0"
       BEGIN
-        VALUE "CompanyName", "Nope Foundry"
+        VALUE "CompanyName", "Nope Forge"
         VALUE "FileDescription", "nope.gl"
         VALUE "FileVersion", "@NOPEGL_VERSION@"
         VALUE "InternalName", "nopegl-@NOPEGL_MAJOR_VERSION@.dll"
@@ -22,7 +22,7 @@ VS_VERSION_INFO VERSIONINFO
         VALUE "ProductName", "nope.gl"
         VALUE "ProductVersion", "@NOPEGL_VERSION@"
         VALUE "Licence", "Apache-2.0 license"
-        VALUE "Info", "https://github.com/NopeFoundry/nope.gl"
+        VALUE "Info", "https://github.com/NopeForge/nope.gl"
       END
     END
     BLOCK "VarFileInfo"

--- a/libnopegl/src/atlas.c
+++ b/libnopegl/src/atlas.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Nope Foundry
+ * Copyright 2023 Nope Forge
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/libnopegl/src/atlas.h
+++ b/libnopegl/src/atlas.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Nope Foundry
+ * Copyright 2023 Nope Forge
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/libnopegl/src/distmap.c
+++ b/libnopegl/src/distmap.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2023 Clément Bœsch <u pkh.me>
- * Copyright 2023 Nope Foundry
+ * Copyright 2023 Nope Forge
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/libnopegl/src/distmap.h
+++ b/libnopegl/src/distmap.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2023 Clément Bœsch <u pkh.me>
- * Copyright 2023 Nope Foundry
+ * Copyright 2023 Nope Forge
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/libnopegl/src/filterschain.c
+++ b/libnopegl/src/filterschain.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2023 Matthieu Bouron <matthieu.bouron@gmail,com>
- * Copyright 2023 Nope Foundry
+ * Copyright 2023 Nope Forge
  * Copyright 2021-2022 GoPro Inc.
  *
  * Licensed to the Apache Software Foundation (ASF) under one

--- a/libnopegl/src/glsl/distmap.frag
+++ b/libnopegl/src/glsl/distmap.frag
@@ -1,6 +1,6 @@
 /*
  * Copyright 2023 Clément Bœsch <u pkh.me>
- * Copyright 2023 Nope Foundry
+ * Copyright 2023 Nope Forge
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/libnopegl/src/glsl/distmap.vert
+++ b/libnopegl/src/glsl/distmap.vert
@@ -1,6 +1,6 @@
 /*
  * Copyright 2023 Clément Bœsch <u pkh.me>
- * Copyright 2023 Nope Foundry
+ * Copyright 2023 Nope Forge
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/libnopegl/src/glsl/helper_noise.glsl
+++ b/libnopegl/src/glsl/helper_noise.glsl
@@ -1,7 +1,7 @@
 /*
  * Copyright 2023 Matthieu Bouron <matthieu.bouron@gmail.com>
  * Copyright 2023 Clément Bœsch <u pkh.me>
- * Copyright 2023 Nope Foundry
+ * Copyright 2023 Nope Forge
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/libnopegl/src/glsl/hwconv.frag
+++ b/libnopegl/src/glsl/hwconv.frag
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Nope Foundry
+ * Copyright 2023 Nope Forge
  * Copyright 2018-2022 GoPro Inc.
  *
  * Licensed to the Apache Software Foundation (ASF) under one

--- a/libnopegl/src/glsl/hwconv.vert
+++ b/libnopegl/src/glsl/hwconv.vert
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Nope Foundry
+ * Copyright 2023 Nope Forge
  * Copyright 2018-2022 GoPro Inc.
  *
  * Licensed to the Apache Software Foundation (ASF) under one

--- a/libnopegl/src/glsl/path.frag
+++ b/libnopegl/src/glsl/path.frag
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Nope Foundry
+ * Copyright 2023 Nope Forge
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/libnopegl/src/glsl/path.glsl
+++ b/libnopegl/src/glsl/path.glsl
@@ -1,6 +1,6 @@
 /*
  * Copyright 2023 Clément Bœsch <u pkh.me>
- * Copyright 2023 Nope Foundry
+ * Copyright 2023 Nope Forge
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/libnopegl/src/glsl/path.vert
+++ b/libnopegl/src/glsl/path.vert
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Nope Foundry
+ * Copyright 2023 Nope Forge
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/libnopegl/src/glsl/source_noise.frag
+++ b/libnopegl/src/glsl/source_noise.frag
@@ -1,6 +1,6 @@
 /*
  * Copyright 2023 Matthieu Bouron <matthieu.bouron@gmail.com>
- * Copyright 2023 Nope Foundry
+ * Copyright 2023 Nope Forge
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/libnopegl/src/glsl/source_noise.vert
+++ b/libnopegl/src/glsl/source_noise.vert
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Nope Foundry
+ * Copyright 2023 Nope Forge
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/libnopegl/src/glsl/text_bg.frag
+++ b/libnopegl/src/glsl/text_bg.frag
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Nope Foundry
+ * Copyright 2023 Nope Forge
  * Copyright 2019-2022 GoPro Inc.
  *
  * Licensed to the Apache Software Foundation (ASF) under one

--- a/libnopegl/src/glsl/text_bg.vert
+++ b/libnopegl/src/glsl/text_bg.vert
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Nope Foundry
+ * Copyright 2023 Nope Forge
  * Copyright 2019-2022 GoPro Inc.
  *
  * Licensed to the Apache Software Foundation (ASF) under one

--- a/libnopegl/src/glsl/text_chars.frag
+++ b/libnopegl/src/glsl/text_chars.frag
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Nope Foundry
+ * Copyright 2023 Nope Forge
  * Copyright 2019-2022 GoPro Inc.
  *
  * Licensed to the Apache Software Foundation (ASF) under one

--- a/libnopegl/src/glsl/text_chars.vert
+++ b/libnopegl/src/glsl/text_chars.vert
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Nope Foundry
+ * Copyright 2023 Nope Forge
  * Copyright 2019-2022 GoPro Inc.
  *
  * Licensed to the Apache Software Foundation (ASF) under one

--- a/libnopegl/src/hwconv.c
+++ b/libnopegl/src/hwconv.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Nope Foundry
+ * Copyright 2023 Nope Forge
  * Copyright 2018-2022 GoPro Inc.
  *
  * Licensed to the Apache Software Foundation (ASF) under one

--- a/libnopegl/src/node_colorkey.c
+++ b/libnopegl/src/node_colorkey.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2023 Clément Bœsch <u pkh.me>
- * Copyright 2023 Nope Foundry
+ * Copyright 2023 Nope Forge
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/libnopegl/src/node_filters.c
+++ b/libnopegl/src/node_filters.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2022 Clément Bœsch <u pkh.me>
- * Copyright 2023 Nope Foundry
+ * Copyright 2023 Nope Forge
  * Copyright 2021-2022 GoPro Inc.
  *
  * Licensed to the Apache Software Foundation (ASF) under one

--- a/libnopegl/src/node_gridlayout.c
+++ b/libnopegl/src/node_gridlayout.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2023 Clément Bœsch <u pkh.me>
- * Copyright 2023 Nope Foundry
+ * Copyright 2023 Nope Forge
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/libnopegl/src/node_renderother.c
+++ b/libnopegl/src/node_renderother.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Nope Foundry
+ * Copyright 2023 Nope Forge
  * Copyright 2021-2022 GoPro Inc.
  * Copyright 2021-2022 Clément Bœsch <u pkh.me>
  *

--- a/libnopegl/src/node_renderpath.c
+++ b/libnopegl/src/node_renderpath.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Nope Foundry
+ * Copyright 2023 Nope Forge
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/libnopegl/src/node_rtt.c
+++ b/libnopegl/src/node_rtt.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2023 Matthieu Bouron <matthieu.bouron@gmail.com>
- * Copyright 2023 Nope Foundry
+ * Copyright 2023 Nope Forge
  * Copyright 2016-2022 GoPro Inc.
  *
  * Licensed to the Apache Software Foundation (ASF) under one

--- a/libnopegl/src/node_texteffect.c
+++ b/libnopegl/src/node_texteffect.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Nope Foundry
+ * Copyright 2023 Nope Forge
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/libnopegl/src/node_timerangefilter.c
+++ b/libnopegl/src/node_timerangefilter.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Nope Foundry
+ * Copyright 2023 Nope Forge
  * Copyright 2017-2022 GoPro Inc.
  *
  * Licensed to the Apache Software Foundation (ASF) under one

--- a/libnopegl/src/nodes_register.h
+++ b/libnopegl/src/nodes_register.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Nope Foundry
+ * Copyright 2023 Nope Forge
  * Copyright 2017-2022 GoPro Inc.
  *
  * Licensed to the Apache Software Foundation (ASF) under one

--- a/libnopegl/src/nopegl.h.in
+++ b/libnopegl/src/nopegl.h.in
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Nope Foundry
+ * Copyright 2023 Nope Forge
  * Copyright 2016-2022 GoPro Inc.
  *
  * Licensed to the Apache Software Foundation (ASF) under one

--- a/libnopegl/src/rtt.c
+++ b/libnopegl/src/rtt.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2023 Matthieu Bouron <matthieu.bouron@gmail.com>
- * Copyright 2023 Nope Foundry
+ * Copyright 2023 Nope Forge
  * Copyright 2016-2022 GoPro Inc.
  *
  * Licensed to the Apache Software Foundation (ASF) under one

--- a/libnopegl/src/rtt.h
+++ b/libnopegl/src/rtt.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2023 Matthieu Bouron <matthieu.bouron@gmail.com>
- * Copyright 2023 Nope Foundry
+ * Copyright 2023 Nope Forge
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/libnopegl/src/scene.c
+++ b/libnopegl/src/scene.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Nope Foundry
+ * Copyright 2023 Nope Forge
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/libnopegl/src/text.c
+++ b/libnopegl/src/text.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2023 Clément Bœsch <u pkh.me>
- * Copyright 2023 Nope Foundry
+ * Copyright 2023 Nope Forge
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/libnopegl/src/text.h
+++ b/libnopegl/src/text.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Nope Foundry
+ * Copyright 2023 Nope Forge
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/libnopegl/src/text_builtin.c
+++ b/libnopegl/src/text_builtin.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Nope Foundry
+ * Copyright 2023 Nope Forge
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/libnopegl/src/text_external.c
+++ b/libnopegl/src/text_external.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Nope Foundry
+ * Copyright 2023 Nope Forge
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/pynopegl-utils/pynopegl_utils/export.py
+++ b/pynopegl-utils/pynopegl_utils/export.py
@@ -1,7 +1,7 @@
 #
 # Copyright 2023 Matthieu Bouron <matthieu.bouron@gmail.com>
 # Copyright 2023 Clément Bœsch <u pkh.me>
-# Copyright 2023 Nope Foundry
+# Copyright 2023 Nope Forge
 # Copyright 2017-2022 GoPro Inc.
 #
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/pynopegl-utils/pynopegl_utils/qml/livectls.py
+++ b/pynopegl-utils/pynopegl_utils/qml/livectls.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Nope Foundry
+# Copyright 2023 Nope Forge
 # Copyright 2022 GoPro Inc.
 #
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/pynopegl-utils/pynopegl_utils/qml/params.py
+++ b/pynopegl-utils/pynopegl_utils/qml/params.py
@@ -1,6 +1,6 @@
 #
 # Copyright 2023 Clément Bœsch <u pkh.me>
-# Copyright 2023 Nope Foundry
+# Copyright 2023 Nope Forge
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/pynopegl-utils/pynopegl_utils/qml/uielements.py
+++ b/pynopegl-utils/pynopegl_utils/qml/uielements.py
@@ -1,6 +1,6 @@
 #
 # Copyright 2023 Clément Bœsch <u pkh.me>
-# Copyright 2023 Nope Foundry
+# Copyright 2023 Nope Forge
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/pynopegl-utils/pynopegl_utils/qml/viewer.qml
+++ b/pynopegl-utils/pynopegl_utils/qml/viewer.qml
@@ -1,6 +1,6 @@
 /*
  * Copyright 2023 Clément Bœsch <u pkh.me>
- * Copyright 2023 Nope Foundry
+ * Copyright 2023 Nope Forge
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/pynopegl-utils/pynopegl_utils/viewer/__init__.py
+++ b/pynopegl-utils/pynopegl_utils/viewer/__init__.py
@@ -1,6 +1,6 @@
 #
 # Copyright 2023 Clément Bœsch <u pkh.me>
-# Copyright 2023 Nope Foundry
+# Copyright 2023 Nope Forge
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -38,15 +38,15 @@ from PySide6.QtCore import QObject, QUrl, Slot
 
 import pynopegl as ngl
 
-_LICENSE_APACHE = "https://github.com/NopeFoundry/nope.gl/blob/main/LICENSE"
-_NOTICE = "https://github.com/NopeFoundry/nope.gl/blob/main/NOTICE"
-_NOPE_FOUNDRY = "https://www.nope-foundry.org"
-_NOPE_MEDIA = "https://github.com/NopeFoundry/nope.media"
+_LICENSE_APACHE = "https://github.com/NopeForge/nope.gl/blob/main/LICENSE"
+_NOTICE = "https://github.com/NopeForge/nope.gl/blob/main/NOTICE"
+_NOPE_FORGE = "https://www.nopeforge.org"
+_NOPE_MEDIA = "https://github.com/NopeForge/nope.media"
 _ABOUT_POPUP_CONTENT = dedent(
     f"""\
     # About
 
-    The Nope viewer is part of the [Nope Foundry]({_NOPE_FOUNDRY}) project and
+    The Nope viewer is part of the [Nope Forge]({_NOPE_FORGE}) project and
     is licensed under the [Apache License, Version 2.0]({_LICENSE_APACHE}).
 
     See the [NOTICE]({_NOTICE}) file for more information.

--- a/pynopegl-utils/pynopegl_utils/viewer/config.py
+++ b/pynopegl-utils/pynopegl_utils/viewer/config.py
@@ -1,6 +1,6 @@
 #
 # Copyright 2023 Clément Bœsch <u pkh.me>
-# Copyright 2023 Nope Foundry
+# Copyright 2023 Nope Forge
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/pynopegl-utils/pynopegl_utils/viewer/ffmpeg_win32.py
+++ b/pynopegl-utils/pynopegl_utils/viewer/ffmpeg_win32.py
@@ -1,6 +1,6 @@
 #
 # Copyright 2023 Matthieu Bouron <matthieu.bouron@gmail.com>
-# Copyright 2023 Nope Foundry
+# Copyright 2023 Nope Forge
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/pynopegl-utils/pynopegl_utils/viewer/scenes.py
+++ b/pynopegl-utils/pynopegl_utils/viewer/scenes.py
@@ -1,6 +1,6 @@
 #
 # Copyright 2023 Clément Bœsch <u pkh.me>
-# Copyright 2023 Nope Foundry
+# Copyright 2023 Nope Forge
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/tests/noise.py
+++ b/tests/noise.py
@@ -1,6 +1,6 @@
 #
 # Copyright 2023 Matthieu Bouron <matthieu.bouron@gmail.com>
-# Copyright 2023 Nope Foundry
+# Copyright 2023 Nope Forge
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/tests/path.py
+++ b/tests/path.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Nope Foundry
+# Copyright 2023 Nope Forge
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/tests/rtt.py
+++ b/tests/rtt.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Nope Foundry
+# Copyright 2023 Nope Forge
 # Copyright 2020-2022 GoPro Inc.
 #
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/tests/scope.py
+++ b/tests/scope.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2022-2023 Nope Foundry
+# Copyright 2022-2023 Nope Forge
 # Copyright 2022 GoPro Inc.
 #
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/tests/texteffect.py
+++ b/tests/texteffect.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Nope Foundry
+# Copyright 2023 Nope Forge
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
To avoid a confusing history, the previous reference to Nope Foundry is removed from the Changelog.