### PR TITLE
Hwconv fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](https://semver.org/spec/v2.0.0.html) for `libnopegl`.
 
 ### Fixed
 - Moving the split position in `ngl-diff`
+- Crash in the hwconv module when direct rendering is not possible/enabled
 
 ### Changed
 - `ngl.get_backends()` and `ngl.probe_backends()` were mistakenly inverted in

--- a/libnopegl/src/hwconv.c
+++ b/libnopegl/src/hwconv.c
@@ -171,8 +171,10 @@ int ngli_hwconv_convert_image(struct hwconv *hwconv, const struct image *image)
     struct pipeline_compat *pipeline = hwconv->pipeline_compat;
 
     const struct darray *texture_infos_array = ngli_pgcraft_get_texture_infos(hwconv->crafter);
-    const struct pgcraft_texture_info *info = ngli_darray_data(texture_infos_array);
     ngli_assert(ngli_darray_count(texture_infos_array) == 1);
+
+    struct pgcraft_texture_info *info = ngli_darray_data(texture_infos_array);
+    info->image = image;
 
     ngli_pipeline_compat_update_texture_info(pipeline, info);
     ngli_pipeline_compat_draw(pipeline, 3, 1);

--- a/libnopegl/src/pgcraft.h
+++ b/libnopegl/src/pgcraft.h
@@ -151,8 +151,8 @@ struct pgcraft_texture_info {
     int precision;
     int writable;
     int format;
-    struct texture *texture;
-    struct image *image;
+    const struct texture *texture;
+    const struct image *image;
     struct pgcraft_texture_info_field fields[NGLI_INFO_FIELD_NB];
 };
 


### PR DESCRIPTION
The crash can be reproduced with ngl-player -d 0 <media> when using a hwaccel.