### PR TITLE
Ptr cast alignment

### DIFF
--- a/libnopegl/src/backends/gl/glcontext.c
+++ b/libnopegl/src/backends/gl/glcontext.c
@@ -125,7 +125,7 @@ static int glcontext_load_functions(struct glcontext *glcontext)
             return NGL_ERROR_NOT_FOUND;
         }
 
-        *(void **)((uint8_t *)gl + gldefinition->offset) = func;
+        *(void **)((uintptr_t)gl + gldefinition->offset) = func;
     }
 
     return 0;
@@ -279,7 +279,7 @@ static int glcontext_check_functions(struct glcontext *glcontext,
         return 1;
 
     while (*funcs_offsets != -1) {
-        void *func_ptr = *(void **)((uint8_t *)gl + *funcs_offsets);
+        void *func_ptr = *(void **)((uintptr_t)gl + *funcs_offsets);
         if (!func_ptr)
             return 0;
         funcs_offsets++;

--- a/libnopegl/src/backends/gl/glcontext_wgl.c
+++ b/libnopegl/src/backends/gl/glcontext_wgl.c
@@ -20,6 +20,7 @@
  */
 
 #include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <Windows.h>
 
@@ -113,7 +114,7 @@ static int wgl_init_extensions(struct glcontext *ctx)
             LOG(ERROR, "could not retrieve %s()", name);
             goto done;
         }
-        memcpy(((uint8_t *)wgl) + offset, &function_ptr, sizeof(function_ptr));
+        memcpy((uintptr_t)wgl + offset, &function_ptr, sizeof(function_ptr));
     }
 
     wgl->SwapIntervalEXT = (PFNWGLSWAPINTERVALEXTPROC)wglGetProcAddress("wglSwapIntervalEXT");

--- a/libnopegl/src/backends/vk/vkcontext.c
+++ b/libnopegl/src/backends/vk/vkcontext.c
@@ -840,7 +840,7 @@ struct vk_extension {
 
 static int load_function(struct vkcontext *s, const struct vk_function *func)
 {
-    PFN_vkVoidFunction *func_ptr = (void *)((uint8_t *)s + func->offset);
+    PFN_vkVoidFunction *func_ptr = (void *)((uintptr_t)s + func->offset);
     if (func->device)
         *func_ptr = vkGetDeviceProcAddr(s->device, func->name);
     else

--- a/libnopegl/src/jni_utils.c
+++ b/libnopegl/src/jni_utils.c
@@ -21,6 +21,7 @@
 
 #include <jni.h>
 #include <stdlib.h>
+#include <stdint.h>
 
 #include "bstr.h"
 #include "jni_utils.h"
@@ -293,7 +294,7 @@ int ngli_jni_init_jfields(JNIEnv *env, void *jfields, const struct JniField *jfi
                 goto done;
             }
 
-            last_cls = *(jclass*)((uint8_t*)jfields + jfields_mapping[i].offset) =
+            last_cls = *(jclass*)((uintptr_t)jfields + jfields_mapping[i].offset) =
                     global ? (*env)->NewGlobalRef(env, cls) : cls;
 
             if (global) {
@@ -314,7 +315,7 @@ int ngli_jni_init_jfields(JNIEnv *env, void *jfields, const struct JniField *jfi
                     goto done;
                 }
 
-                *(jfieldID*)((uint8_t*)jfields + jfields_mapping[i].offset) = field_id;
+                *(jfieldID*)((uintptr_t)jfields + jfields_mapping[i].offset) = field_id;
                 break;
             }
             case NGLI_JNI_STATIC_FIELD: {
@@ -323,7 +324,7 @@ int ngli_jni_init_jfields(JNIEnv *env, void *jfields, const struct JniField *jfi
                     goto done;
                 }
 
-                *(jfieldID*)((uint8_t*)jfields + jfields_mapping[i].offset) = field_id;
+                *(jfieldID*)((uintptr_t)jfields + jfields_mapping[i].offset) = field_id;
                 break;
             }
             case NGLI_JNI_METHOD: {
@@ -332,7 +333,7 @@ int ngli_jni_init_jfields(JNIEnv *env, void *jfields, const struct JniField *jfi
                     goto done;
                 }
 
-                *(jmethodID*)((uint8_t*)jfields + jfields_mapping[i].offset) = method_id;
+                *(jmethodID*)((uintptr_t)jfields + jfields_mapping[i].offset) = method_id;
                 break;
             }
             case NGLI_JNI_STATIC_METHOD: {
@@ -341,7 +342,7 @@ int ngli_jni_init_jfields(JNIEnv *env, void *jfields, const struct JniField *jfi
                     goto done;
                 }
 
-                *(jmethodID*)((uint8_t*)jfields + jfields_mapping[i].offset) = method_id;
+                *(jmethodID*)((uintptr_t)jfields + jfields_mapping[i].offset) = method_id;
                 break;
             }
             default:
@@ -372,7 +373,7 @@ int ngli_jni_reset_jfields(JNIEnv *env, void *jfields, const struct JniField *jf
 
         switch(type) {
         case NGLI_JNI_CLASS: {
-            jclass cls = *(jclass*)((uint8_t*)jfields + jfields_mapping[i].offset);
+            jclass cls = *(jclass*)((uintptr_t)jfields + jfields_mapping[i].offset);
             if (!cls)
                 continue;
 
@@ -382,23 +383,23 @@ int ngli_jni_reset_jfields(JNIEnv *env, void *jfields, const struct JniField *jf
                 (*env)->DeleteLocalRef(env, cls);
             }
 
-            *(jclass*)((uint8_t*)jfields + jfields_mapping[i].offset) = NULL;
+            *(jclass*)((uintptr_t)jfields + jfields_mapping[i].offset) = NULL;
             break;
         }
         case NGLI_JNI_FIELD: {
-            *(jfieldID*)((uint8_t*)jfields + jfields_mapping[i].offset) = NULL;
+            *(jfieldID*)((uintptr_t)jfields + jfields_mapping[i].offset) = NULL;
             break;
         }
         case NGLI_JNI_STATIC_FIELD: {
-            *(jfieldID*)((uint8_t*)jfields + jfields_mapping[i].offset) = NULL;
+            *(jfieldID*)((uintptr_t)jfields + jfields_mapping[i].offset) = NULL;
             break;
         }
         case NGLI_JNI_METHOD: {
-            *(jmethodID*)((uint8_t*)jfields + jfields_mapping[i].offset) = NULL;
+            *(jmethodID*)((uintptr_t)jfields + jfields_mapping[i].offset) = NULL;
             break;
         }
         case NGLI_JNI_STATIC_METHOD: {
-            *(jmethodID*)((uint8_t*)jfields + jfields_mapping[i].offset) = NULL;
+            *(jmethodID*)((uintptr_t)jfields + jfields_mapping[i].offset) = NULL;
             break;
         }
         default:


### PR DESCRIPTION
This does not solve any real issue as we are not manually interleaving data inside allocated memory region. When we do, like in the ngl_node allocation code, we properly pad each structs (pub, opts, priv)).
It is considered a better practice to use uintptr_t for platforms supporting it, to perform pointer arithmetic. Moreover it silences warnings when building libnopegl with -Wcast-align=strict.