### PR TITLE
hwmap_mediacodec_gl: fix NULL pointer dereference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Versioning](https://semver.org/spec/v2.0.0.html) for `libnopegl`.
 - Moving the split position in `ngl-diff`
 - Crash in the hwconv module when direct rendering is not possible/enabled
 - Export to output files containing spaces in their path on Windows
+- Crash when decoding videos on Android with the OpenGLES backend
 
 ### Changed
 - `ngl.get_backends()` and `ngl.probe_backends()` were mistakenly inverted in

--- a/libnopegl/src/backends/gl/hwmap_mediacodec_gl.c
+++ b/libnopegl/src/backends/gl/hwmap_mediacodec_gl.c
@@ -169,6 +169,8 @@ static int mc_map_frame_imagereader(struct hwmap *hwmap, struct nmd_frame *frame
     struct glcontext *gl = gpu_ctx_gl->glcontext;
     struct android_ctx *android_ctx = &ctx->android_ctx;
 
+    ngli_texture_gl_set_dimensions(mc->texture, frame->width, frame->height, 0);
+
     int ret = nmd_mc_frame_render_and_releasep(&frame);
     if (ret < 0)
         return ret;
@@ -221,8 +223,6 @@ static int mc_map_frame_imagereader(struct hwmap *hwmap, struct nmd_frame *frame
 
     ngli_glBindTexture(gl, GL_TEXTURE_EXTERNAL_OES, id);
     ngli_glEGLImageTargetTexture2DOES(gl, GL_TEXTURE_EXTERNAL_OES, mc->egl_image);
-
-    ngli_texture_gl_set_dimensions(mc->texture, frame->width, frame->height, 0);
 
     return 0;
 }


### PR DESCRIPTION
Fixes regression introduced by 7d297568172172e4047beb7d731a3a9dd91c41d5.