### PR TITLE
build: bump glslang version to 14.0.0

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -153,10 +153,10 @@ _EXTERNAL_DEPS = dict(
         sha256="446cf6277ff0dd4211e6dc19c1b9015210a72758f53f5034c7e4d6b60e540ecf",
     ),
     glslang=dict(
-        version="13.1.1",
+        version="14.0.0",
         dst_file="glslang-@VERSION@.tar.gz",
         url="https://github.com/KhronosGroup/glslang/archive/refs/tags/@VERSION@.tar.gz",
-        sha256="1c4d0a5a38c8aaf89a2d7e6093be734320599f5a6775b2726beeb05b0c054e66",
+        sha256="80bbb916a23e94ea9cbfb1acb5d1a44a7e0c9613bcf5b5947c03f2273bdc92b0",
     ),
     glslang_Windows=dict(
         # Use the legacy master-tot Windows build until the main-tot one is

--- a/libnopegl/meson.build
+++ b/libnopegl/meson.build
@@ -555,6 +555,8 @@ foreach gbackend_name, gbackend_cfg : gbackends_cfg
       #   libOGLCompiler.a, libGenericCodeGen.a, libSPVRemapper.a, libSPIRV.a
       #   libSPIRV-Tools-opt.a (optional), libSPIRV-Tools.a (optional) are
       #   installed.
+      # - Since glslang 14.0.0, the legacy HLSL and OGLCompiler libraries have
+      #   been removed
       # The following list declares the glslang libraries that we need to check
       # and link against in the right order (to allow static linking). Some
       # libraries are marked as non-required because they might be present or
@@ -564,7 +566,7 @@ foreach gbackend_name, gbackend_cfg : gbackends_cfg
         {'name': 'glslang-default-resource-limits', 'required': true},
         {'name': 'MachineIndependent',              'required': false},
         {'name': 'OSDependent',                     'required': false},
-        {'name': 'HLSL',                            'required': true},
+        {'name': 'HLSL',                            'required': false},
         {'name': 'OGLCompiler',                     'required': false},
         {'name': 'GenericCodeGen',                  'required': false},
         {'name': 'SPVRemapper',                     'required': true},


### PR DESCRIPTION
According to upstream release notes, legacy HLSL and OGLCompiler libraries have been removed.