### PR TITLE
gpu_ctx: remove viewport parameter from ngli_gpu_ctx_resize()

### DIFF
--- a/libnopegl/src/api.c
+++ b/libnopegl/src/api.c
@@ -418,9 +418,14 @@ fail:
 
 int ngli_ctx_resize(struct ngl_ctx *s, int32_t width, int32_t height)
 {
+    int ret = ngli_gpu_ctx_resize(s->gpu_ctx, width, height);
+    if (ret < 0)
+        return ret;
+
     struct viewport vp = compute_scene_viewport(s->scene, width, height);
-    const int32_t vp_i32[] = {vp.x, vp.y, vp.width, vp.height};
-    return ngli_gpu_ctx_resize(s->gpu_ctx, width, height, vp_i32);
+    ngli_gpu_ctx_set_viewport(s->gpu_ctx, &vp);
+
+    return 0;
 }
 
 int ngli_ctx_get_viewport(struct ngl_ctx *s, int32_t *viewport)

--- a/libnopegl/src/backends/gl/gpu_ctx_gl.c
+++ b/libnopegl/src/backends/gl/gpu_ctx_gl.c
@@ -549,7 +549,7 @@ static int gl_init(struct gpu_ctx *s)
     return 0;
 }
 
-static int gl_resize(struct gpu_ctx *s, int32_t width, int32_t height, const int32_t *viewport)
+static int gl_resize(struct gpu_ctx *s, int32_t width, int32_t height)
 {
     struct gpu_ctx_gl *s_priv = (struct gpu_ctx_gl *)s;
     struct glcontext *gl = s_priv->glcontext;
@@ -586,13 +586,8 @@ static int gl_resize(struct gpu_ctx *s, int32_t width, int32_t height, const int
         rt_gl->id = rt_load_gl->id = ngli_glcontext_get_default_framebuffer(gl);
     }
 
-    const struct viewport vp = {NGLI_ARG_VEC4(viewport)};
-    if (ngli_viewport_is_valid(&vp)) {
-        ngli_gpu_ctx_set_viewport(s, &vp);
-    } else {
-        const struct viewport default_vp = {0, 0, width, height};
-        ngli_gpu_ctx_set_viewport(s, &default_vp);
-    }
+    const struct viewport viewport = {0, 0, width, height};
+    ngli_gpu_ctx_set_viewport(s, &viewport);
 
     const struct scissor scissor = {0, 0, width, height};
     ngli_gpu_ctx_set_scissor(s, &scissor);

--- a/libnopegl/src/backends/vk/gpu_ctx_vk.c
+++ b/libnopegl/src/backends/vk/gpu_ctx_vk.c
@@ -767,14 +767,10 @@ static uint32_t get_max_color_attachments(const VkPhysicalDeviceLimits *limits)
     return NGLI_MIN(limits->maxColorAttachments, NGLI_MAX_COLOR_ATTACHMENTS);
 }
 
-static void set_viewport_and_scissor(struct gpu_ctx *s, int32_t width, int32_t height, const struct viewport *viewport)
+static void set_viewport_and_scissor(struct gpu_ctx *s, int32_t width, int32_t height)
 {
-    if (ngli_viewport_is_valid(viewport)) {
-        ngli_gpu_ctx_set_viewport(s, viewport);
-    } else {
-        const struct viewport default_viewport = {0, 0, width, height};
-        ngli_gpu_ctx_set_viewport(s, &default_viewport);
-    }
+    const struct viewport viewport = {0, 0, width, height};
+    ngli_gpu_ctx_set_viewport(s, &viewport);
 
     const struct scissor scissor = {0, 0, width, height};
     ngli_gpu_ctx_set_scissor(s, &scissor);
@@ -963,13 +959,12 @@ static int vk_init(struct gpu_ctx *s)
         s_priv->default_rt_layout.depth_stencil.resolve = 0;
     }
 
-    const struct viewport viewport = {0, 0, config->width, config->height};
-    set_viewport_and_scissor(s, config->width, config->height, &viewport);
+    set_viewport_and_scissor(s, config->width, config->height);
 
     return 0;
 }
 
-static int vk_resize(struct gpu_ctx *s, int32_t width, int32_t height, const int32_t *viewport)
+static int vk_resize(struct gpu_ctx *s, int32_t width, int32_t height)
 {
     const struct ngl_config *config = &s->config;
     struct gpu_ctx_vk *s_priv = (struct gpu_ctx_vk *)s;
@@ -983,8 +978,7 @@ static int vk_resize(struct gpu_ctx *s, int32_t width, int32_t height, const int
     s_priv->width = width;
     s_priv->height = height;
 
-    const struct viewport vp = {NGLI_ARG_VEC4(viewport)};
-    set_viewport_and_scissor(s, width, height, &vp);
+    set_viewport_and_scissor(s, width, height);
 
     return 0;
 }

--- a/libnopegl/src/gpu_ctx.c
+++ b/libnopegl/src/gpu_ctx.c
@@ -105,10 +105,10 @@ int ngli_gpu_ctx_init(struct gpu_ctx *s)
     return 0;
 }
 
-int ngli_gpu_ctx_resize(struct gpu_ctx *s, int32_t width, int32_t height, const int32_t *viewport)
+int ngli_gpu_ctx_resize(struct gpu_ctx *s, int32_t width, int32_t height)
 {
     const struct gpu_ctx_class *cls = s->cls;
-    return cls->resize(s, width, height, viewport);
+    return cls->resize(s, width, height);
 }
 
 int ngli_gpu_ctx_set_capture_buffer(struct gpu_ctx *s, void *capture_buffer)

--- a/libnopegl/src/gpu_ctx.h
+++ b/libnopegl/src/gpu_ctx.h
@@ -55,7 +55,7 @@ struct gpu_ctx_class {
 
     struct gpu_ctx *(*create)(const struct ngl_config *config);
     int (*init)(struct gpu_ctx *s);
-    int (*resize)(struct gpu_ctx *s, int32_t width, int32_t height, const int32_t *viewport);
+    int (*resize)(struct gpu_ctx *s, int32_t width, int32_t height);
     int (*set_capture_buffer)(struct gpu_ctx *s, void *capture_buffer);
     int (*begin_update)(struct gpu_ctx *s, double t);
     int (*end_update)(struct gpu_ctx *s, double t);
@@ -157,7 +157,7 @@ struct gpu_ctx {
 
 struct gpu_ctx *ngli_gpu_ctx_create(const struct ngl_config *config);
 int ngli_gpu_ctx_init(struct gpu_ctx *s);
-int ngli_gpu_ctx_resize(struct gpu_ctx *s, int32_t width, int32_t height, const int32_t *viewport);
+int ngli_gpu_ctx_resize(struct gpu_ctx *s, int32_t width, int32_t height);
 int ngli_gpu_ctx_set_capture_buffer(struct gpu_ctx *s, void *capture_buffer);
 int ngli_gpu_ctx_begin_update(struct gpu_ctx *s, double t);
 int ngli_gpu_ctx_end_update(struct gpu_ctx *s, double t);


### PR DESCRIPTION
Depends on https://github.com/NopeForge/nope.gl/pull/229.