### PR TITLE
hblur: remove superfluous allocation

### DIFF
--- a/libnopegl/src/node_hblur.c
+++ b/libnopegl/src/node_hblur.c
@@ -515,12 +515,6 @@ static int resize(struct ngl_node *node)
             goto fail;
     }
 
-    pass2_rtt_ctx = ngli_rtt_create(ctx);
-    if (!pass2_rtt_ctx) {
-        ret = NGL_ERROR_MEMORY;
-        goto fail;
-    }
-
     const struct rtt_params pass2_rtt_params = {
         .width  = dst->params.width,
         .height = dst->params.height,


### PR DESCRIPTION
pass2_rtt_ctx is already allocated earlier in the function.

Fixes CID 1584829.