### PR TITLE
ci: bump Ubuntu version from 22.04 to 24.04

### DIFF
--- a/.github/workflows/ci_android.yml
+++ b/.github/workflows/ci_android.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   android-build:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci_coverage.yml
+++ b/.github/workflows/ci_coverage.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   coverage:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ci_coverity.yml
+++ b/.github/workflows/ci_coverity.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   linux:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     if: ${{ github.repository_owner == 'NopeForge' }}
     steps:

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   linux:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -22,7 +22,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout sources

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -10,7 +10,7 @@ jobs:
 
     permissions:
       contents: write
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/doc/usr/howto/installation.md
+++ b/doc/usr/howto/installation.md
@@ -27,7 +27,7 @@ building and running the complete `nope.gl` stack.
     typically named with a `-dev` suffix on Debian based systems)
   - **Graphviz**
   - **SDL2**
-  - **Glslang**
+  - **Glslang ≥ 11.13.0**
   - **MoltenVK** (macOS, optional)
 - Build with `./configure.py && make`
 - Enter the virtual environment with `. venv/bin/ngli-activate`

--- a/libnopegl/meson.build
+++ b/libnopegl/meson.build
@@ -601,7 +601,7 @@ foreach gbackend_name, gbackend_cfg : gbackends_cfg
           )
         endforeach
         glslang_ver = '.'.join(glslang_ver_array)
-        glslang_min_ver = '>= 11.3.0'
+        glslang_min_ver = '>= 11.13.0'
         if glslang_ver.version_compare(glslang_min_ver)
           gbackend_deps += declare_dependency(include_directories: glslang_include_dirs)
         else

--- a/libnopegl/src/backends/vk/glslang_utils.c
+++ b/libnopegl/src/backends/vk/glslang_utils.c
@@ -24,6 +24,7 @@
 #include <string.h>
 #include <glslang/build_info.h>
 #include <glslang/Include/glslang_c_interface.h>
+#include <glslang/Public/resource_limits_c.h>
 
 #include "glslang_utils.h"
 #include "log.h"
@@ -31,13 +32,6 @@
 #include "nopegl.h"
 #include "program.h"
 #include "pthread_compat.h"
-
-/*
- * resource_limits_c.h which declares glslang_default_resource() is currently
- * not distributed, so forward declare it.
- * See: https://github.com/KhronosGroup/glslang/issues/2822
- */
-const glslang_resource_t *glslang_default_resource(void);
 
 static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
 static int refcount = 0;


### PR DESCRIPTION
Depends on https://github.com/NopeForge/nope.gl/pull/258 and Ubuntu 24.04 CI support (public beta is planned for mid may).