### PR TITLE
build: simplify small build logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Versioning](https://semver.org/spec/v2.0.0.html) for `libnopegl`.
 - `Text.aspect_ratio`, it now matches the viewport aspect ratio
 - `GraphicConfig.scissor_test` parameter
 - Support for Android < 9.0
+- The `small` build option (enabled by default now)
 
 ## [2024.0 / libnopegl 0.11.0][2024.0] - 2024-02-02
 ### Added

--- a/libnopegl/meson.build
+++ b/libnopegl/meson.build
@@ -93,7 +93,6 @@ install_rpath = get_option('rpath') ? get_option('prefix') / get_option('libdir'
 debug_opts = get_option('debug_opts')
 conf_data.set10('TARGET_' + host_system.to_upper(), true)
 conf_data.set10('ARCH_' + cpu_family.to_upper(), true)
-conf_data.set10('CONFIG_SMALL', get_option('small'))
 conf_data.set10('DEBUG_GL', 'gl' in debug_opts)
 conf_data.set10('DEBUG_VK', 'vk' in debug_opts)
 conf_data.set10('DEBUG_MEM', 'mem' in debug_opts)
@@ -842,10 +841,6 @@ specs_filename = 'nodes.specs'
 dest_datadir = get_option('datadir') / 'nopegl'
 install_data(files(specs_filename), install_dir: dest_datadir)
 
-# XXX: should we use an intermediate static_library() to share the objects
-# between the library and these tools?
-# https://git.archlinux.org/pacman.git/tree/meson.build?id=4533c6a8e0f39c7707e671b7f9687607b46f1417#n310
-# seem to imply some extract_all_objects(recursive: true)
 gen_specs = executable(
   'gen_specs',
   lib_src + files('src/gen_specs.c'),
@@ -853,6 +848,7 @@ gen_specs = executable(
   build_by_default: false,
   native: true,
   include_directories: inc_dir,
+  c_args: '-DINCLUDE_DOCSTRINGS',
 )
 specs_file = custom_target(
   specs_filename,

--- a/libnopegl/meson_options.txt
+++ b/libnopegl/meson_options.txt
@@ -34,8 +34,6 @@ option('vaapi-wayland', type: 'feature', value: 'auto',
 
 option('rpath', type: 'boolean', value: false,
        description: 'install with rpath')
-option('small', type: 'boolean', value: false,
-       description: 'exclude all the documentation strings from the binary')
 option('tests', type: 'boolean', value: true)
 
 option('logtrace', type: 'boolean', value: false,

--- a/libnopegl/src/utils/utils.h
+++ b/libnopegl/src/utils/utils.h
@@ -99,7 +99,7 @@
 #define NGLI_ALIGNED_VEC(vname) float NGLI_ATTR_ALIGNED vname[4]
 #define NGLI_ALIGNED_MAT(mname) float NGLI_ATTR_ALIGNED mname[4*4]
 
-#if CONFIG_SMALL
+#ifndef INCLUDE_DOCSTRINGS
 #define NGLI_DOCSTRING(s) (NULL)
 #else
 #define NGLI_DOCSTRING(s) (s)


### PR DESCRIPTION
Now docstrings are not included in the library anymore (5.1M to 5.0M on a release build) and only present for the gen_specs executable.

The comment in the meson build is removed because we won't be able to share the object anymore since they are built with different options.